### PR TITLE
Proposed new color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ plt.style.use(['./mphowardlab.mplstyle','./aip.mplstyle'])
 
 ### Colors
 
-The default color cyle is based on [ColorBrewer][3]'s *Set1* pallete. These colors are printer safe and compatible with ColorBrewer's sequential and diverging palletes. 
+The default color cyle is based on [ColorBrewer][3]'s *Set1* pallete. These colors are printer safe and compatible with ColorBrewer's sequential and diverging palletes. The colors may be manually specified in plot commands as:
 
 * `C0`: red
 * `C1`: blue

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ plt.style.use(['./mphowardlab.mplstyle','./aip.mplstyle'])
 
 ### Colors
 
-The default color cyle implements the following colors that may be manually specified
-in plot commands:
+The default color cyle is based on [ColorBrewer][3]'s *Set1* pallete. These colors are printer safe and compatible with ColorBrewer's sequential and diverging palletes. 
 
 * `C0`: red
 * `C1`: blue
@@ -85,3 +84,4 @@ For detailed style file options, see this [tutorial][2] with an example
 
 [1]: https://matplotlib.org
 [2]: https://matplotlib.org/stable/tutorials/introductory/customizing.html
+[3]: https://colorbrewer2.org

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ plt.style.use(['./mphowardlab.mplstyle','./aip.mplstyle'])
 
 ### Colors
 
-The default color cyle is based on [ColorBrewer][3]'s *Set1* pallete. These colors are printer safe and compatible with ColorBrewer's sequential and diverging palletes. The colors may be manually specified in plot commands as:
+The default color cycle is based on [ColorBrewer][3]'s *Set1* pallete. These colors are printer safe and compatible with ColorBrewer's sequential and diverging palettes. The colors may be manually specified in plot commands as:
 
 * `C0`: red
 * `C1`: blue

--- a/stylelib/mphowardlab.mplstyle
+++ b/stylelib/mphowardlab.mplstyle
@@ -16,7 +16,7 @@ axes.labelsize : 10
 axes.labelpad : 4
 axes.formatter.limits: -3,4
 # red, blue, green, orange, purple, pink, gold, grey, black
-axes.prop_cycle : cycler(color=['cc0000','0000cc','009900','ff8000','6f00ff','e500e5','e5c100','858585','000000'])
+axes.prop_cycle : cycler(color=['e41a1c','377eb8','4daf4a','ff7f00','984ea3','f781bf','e5c100','999999','000000'])
 
 ## TICKS
 xtick.top : True


### PR DESCRIPTION
I propose updating our color palette to the colors used by [Color Brewer](https://colorbrewer2.org/). These colors are supposed to be printer safe and have been carefully chosen to work well for cartography. Additionally, they play nice when needing to use their Sequential or Diverging color palettes which I've found useful. I've used the Color Brewer's palettes pretty extensively in my last couple of papers. 

I've proposed pretty much a one to one swap from our current colors: 
<img width="970" height="970" alt="current_colors" src="https://github.com/user-attachments/assets/643d7fc8-7877-405a-b1a3-4555d9388e27" />
to these:
<img width="970" height="970" alt="proposed_colors" src="https://github.com/user-attachments/assets/3f87f8e2-2233-410e-9dc9-290437c49b1b" />

The indigo is replaced with a more purple and the magenta more pink. I think these are easier to distinguish. I've always had a hard time telling the current C1 and C4 apart, especially on projectors.  The one exception is that I've opted to keep your yellow. The color brewer yellow is very harsh... more French's rather than Dijon haha! 