### PR TITLE
Set title font size for axes and figure

### DIFF
--- a/stylelib/mphowardlab.mplstyle
+++ b/stylelib/mphowardlab.mplstyle
@@ -13,6 +13,7 @@ mathtext.fontset : cm
 ### AXES
 axes.linewidth : 1
 axes.labelsize : 10
+axes.titlesize : 10
 axes.labelpad : 4
 axes.formatter.limits: -3,4
 # red, blue, green, orange, purple, pink, gold, grey, black
@@ -43,6 +44,7 @@ legend.borderpad : 0.2
 ## FIGURE
 figure.figsize : 3.37, 1.97
 figure.dpi : 600
+figure.titlesize : 10
 
 ## SAVING FIGURES
 savefig.bbox : tight


### PR DESCRIPTION
This sets the font size of sub-plot and figure titles to 10 pt--- the same as our regular text. This is the most common use case for our figures and is one less thing to have to manually set in a plotting script. 